### PR TITLE
Fix: compile error in abl-emh1.yaml

### DIFF
--- a/abl-emh1.yaml
+++ b/abl-emh1.yaml
@@ -80,7 +80,7 @@ text_sensor:
         if (id(l3_current).state > 1.0)
           phaseCnt++;
       }
-      std::__cxx11::string result;
+      std::string result;
       switch (phaseCnt){
         case 0: 
           result = "None";


### PR DESCRIPTION
When trying to compile the abl-emh1.yaml with the newest ESPHome version (2024.7.2) you will encounter an error with the lambda expression of the chargemode sensor. Simply by removing `__cxx11::` this error is fixed and everything works as expected