### PR TITLE
No current allowed

### DIFF
--- a/abl-emh1.yaml
+++ b/abl-emh1.yaml
@@ -68,7 +68,7 @@ text_sensor:
     update_interval: 5s
     disabled_by_default: true
     lambda: |-
-      int phaseCnt = 0; 
+      int phaseCnt = 0;
       if (id(outlet_state).state == 0xC2) {
         if (id(l1_current).state > 1.0)
           phaseCnt++;
@@ -91,36 +91,36 @@ sensor:
     l1_current:
       name: "L1 current"
       state_class: "measurement"
-      accuracy_decimals: 0
+      accuracy_decimals: 1
       id: l1_current
     l2_current:
       name: "L2 current"
       state_class: "measurement"
-      accuracy_decimals: 0
+      accuracy_decimals: 1
       id: l2_current
     l3_current:
       name: "L3 current"
       state_class: "measurement"
-      accuracy_decimals: 0
+      accuracy_decimals: 1
       id: l3_current
     max_current:
       name: "Max current"
       state_class: "measurement"
       id: max_current
-      disabled_by_default: true 
-      accuracy_decimals: 0
+      disabled_by_default: true
+      accuracy_decimals: 1
     en1_status:
       name: "EN1 status"
-      disabled_by_default: true 
+      disabled_by_default: true
     en2_status:
       name: "EN2 status"
-      disabled_by_default: true 
+      disabled_by_default: true
     duty_cycle_reduced:
       name: "Reduced Duty Cycle (max_current)"
-      disabled_by_default: true 
+      disabled_by_default: true
     ucp_status:
       name: "Ucp Status <= 10V"
-      disabled_by_default: true 
+      disabled_by_default: true
     outlet_state:
       name: "Outlet state"
       disabled_by_default: true
@@ -141,14 +141,14 @@ number:
     icon: mdi:arrow-oscillating
     min_value: 6
     max_value: 32
-    step: 1
+    step: 0.1
     optimistic: false
     lambda: 'return std::lround(id(max_current).state);'
     update_interval: 10s
     set_action:
       lambda: |-
-        ESP_LOGD("main", "Sending modbus value = %d", std::lround(x));
-        id(modbus0)->send_current(std::lround(x));
+        ESP_LOGD("main", "Sending modbus value = %.2f", x);
+        id(modbus0)->send_current(x);
 
 switch:
   - platform: template
@@ -156,18 +156,19 @@ switch:
     id: enable_switch
     icon: "mdi:power"
     lambda: 'return (id(outlet_state).state != 0xE0);'
-    turn_off_action: 
+    turn_off_action:
       - lambda: |-
-          if ((id(abl_uptime).state > 10.0) && (id(outlet_state).state != NAN)) 
+          if ((id(abl_uptime).state > 10.0) && (id(outlet_state).state != NAN))
             id(modbus0)->send_enable(0);
-    turn_on_action: 
+    turn_on_action:
       - lambda: |-
           if ((id(abl_uptime).state > 10.0) && (id(outlet_state).state != NAN))
             id(modbus0)->send_enable(1);
   - platform: template
-    name: "Allow chaging"
+    name: "Allow charging"
     id: allow_charging_switch
     icon: "mdi:power"
+    restore_mode: DISABLED
     lambda: 'return id(charging_allowed).state == 1;'
     turn_on_action:
       - lambda: |-

--- a/abl-emh1.yaml
+++ b/abl-emh1.yaml
@@ -1,10 +1,12 @@
 substitutions:
   name: abl_emh1
   device_description: "Monitor and configure ABL eMH1 Charger via RS485/Modbus-ASCII"
-  external_components_source: github://pascal-t/esphome-abl-emh1@no-current-allowed
+  external_components_source: github://jrv/esphome-abl-emh1@main
   tx_pin: "17"
   rx_pin: "16"
   flow_control_pin: "5"
+  wallbox_min_current: "0"
+  wallbox_max_current: "32"
 
 esphome:
   name: ${name}
@@ -139,8 +141,8 @@ number:
     name: "Max Amps"
     id: set_current
     icon: mdi:arrow-oscillating
-    min_value: 6
-    max_value: 32
+    min_value: ${wallbox_min_current}
+    max_value: ${wallbox_max_current}
     step: 0.1
     optimistic: false
     lambda: 'return std::lround(id(max_current).state);'
@@ -155,6 +157,7 @@ switch:
     name: "Enable"
     id: enable_switch
     icon: "mdi:power"
+    restore_mode: DISABLED
     lambda: 'return (id(outlet_state).state != 0xE0);'
     turn_off_action:
       - lambda: |-
@@ -175,7 +178,7 @@ switch:
           if (id(outlet_state).state == NAN) return;
           int state = std::roundl(id(charging_allowed).state);
           ESP_LOGD("main", "Allow charging turn on. Current state is: %d", state);
-          if (state <= 0) id(modbus0)->send_current(16);
+          if (state <= 0) id(modbus0)->send_current(${wallbox_max_current});
     turn_off_action:
       - lambda: |-
           if (id(outlet_state).state == NAN) return;

--- a/components/abl_emh1/abl_emh1.cpp
+++ b/components/abl_emh1/abl_emh1.cpp
@@ -87,11 +87,11 @@ void ABLeMH1::decode_status_report_(const uint8_t *data, uint16_t datalength) {
   this->publish_state_(this->duty_cycle_reduced_, (data[2] & 0x40) >> 6);
   this->publish_state_(this->ucp_status_sensor_, (data[2] & 0x80) >> 7);
   if ((STATECODE[x] == 0xC2) || (STATECODE[x] == 0xC3) || (STATECODE[x] == 0xC4)) {
-    this->publish_state_(this->l1_current_sensor_,
+    this->publish_state_(this->l3_current_sensor_,
                          ((data[4] << 8) + data[5]) / 10.0);
     this->publish_state_(this->l2_current_sensor_,
                          ((data[6] << 8) + data[7]) / 10.0);
-    this->publish_state_(this->l3_current_sensor_,
+    this->publish_state_(this->l1_current_sensor_,
                          ((data[8] << 8) + data[9]) / 10.0);
   } else {
     this->publish_state_(this->l1_current_sensor_, 0.0);

--- a/components/emh1_modbus/emh1_modbus.cpp
+++ b/components/emh1_modbus/emh1_modbus.cpp
@@ -2,7 +2,6 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 #include "esphome.h"
-#include <cstdint>
 
 namespace esphome {
 namespace emh1_modbus {
@@ -28,7 +27,10 @@ void eMH1Modbus::setup() {
 void eMH1Modbus::loop() {
   const uint32_t now = millis();
   if (now - this->last_emh1_modbus_byte_ > 50) {
-    this->rx_buffer_.clear();
+    if (!this->rx_buffer_.empty()) {
+      ESP_LOGW(TAG, "Transmission interrupted. Discarding buffer.");
+      this->rx_buffer_.clear();
+    }
     this->last_emh1_modbus_byte_ = now;
   }
 


### PR DESCRIPTION
Hi, I still had some changes laying around. I'm sorry that I went quiet for the last few weeks, but some things happened in my personal life.

So the changes are for the following:

- Update the ESPHome config:
  - use the 0.1 steps / 1 decimal place, because it is now possible.
  - use `restore_mode: DISABLED` because after a reboot of the controller the wallbox would be turned off
  - use a substitution for the max current of the wallbox, because it is also used when turn_on of Allow charging
 - Swap the order of the Phase currents. I cross checked with EVCC and it behaves the same.
 - Log dropped incoming messages: I got some "LRC Check failed" messages an I wanted to check if it was because the buffer was cleared prematurely.  